### PR TITLE
Removed AutoLaunch path option

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -117,13 +117,8 @@ mb.on('show', function show () {
   mb.window.webContents.send('show')
 })
 
-const appPath = app.getPath('exe').split('.app/Content')[0] + '.app'
-
-console.log(appPath)
-
 const appLauncher = new AutoLaunch({
   name: 'temps',
-  path: appPath,
   isHidden: true
 })
 


### PR DESCRIPTION
As the AutoLaunch docs mention, the path option is optional for electron apps and it works great without it (at least on Linux).

Hopefully fixes #33 